### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/mocha": "8.2.0",
     "@wildpeaks/eslint-config-typescript": "10.7.0",
     "@wildpeaks/tsconfig-node": "2.11.1",
-    "eslint": "7.17.0",
+    "eslint": "7.18.0",
     "mocha": "8.2.1",
     "ts-node": "9.1.1",
     "typescript": "4.1.3"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/mocha": "8.2.0",
     "@wildpeaks/eslint-config-typescript": "11.0.0-rc1",
-    "@wildpeaks/tsconfig-node": "2.11.1",
+    "@wildpeaks/tsconfig": "4.0.0-rc1",
     "eslint": "7.18.0",
     "mocha": "8.2.1",
     "ts-node": "9.1.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/mocha": "8.2.0",
     "@types/node": "14.14.21",
     "@wildpeaks/eslint-config-typescript": "11.0.0-rc1",
-    "@wildpeaks/tsconfig": "4.0.0-rc1",
+    "@wildpeaks/tsconfig": "4.0.0-rc2",
     "eslint": "7.18.0",
     "mocha": "8.2.1",
     "ts-node": "9.1.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/mocha": "8.2.0",
-    "@wildpeaks/eslint-config-typescript": "10.7.0",
+    "@wildpeaks/eslint-config-typescript": "11.0.0-rc1",
     "@wildpeaks/tsconfig-node": "2.11.1",
     "eslint": "7.18.0",
     "mocha": "8.2.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@types/mocha": "8.2.0",
+    "@types/node": "14.14.21",
     "@wildpeaks/eslint-config-typescript": "11.0.0-rc1",
     "@wildpeaks/tsconfig": "4.0.0-rc1",
     "eslint": "7.18.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@wildpeaks/tsconfig-node": "2.11.1",
     "eslint": "7.17.0",
     "mocha": "8.2.1",
-    "prettier": "2.2.1",
     "ts-node": "9.1.1",
     "typescript": "4.1.3"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,10 @@
 {
+	"ts-node": {
+		"skipIgnore": true,
+		"transpileOnly": true,
+		"compilerOptions": {
+			"module": "CommonJS"
+		}
+	},
 	"extends": "@wildpeaks/tsconfig"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,3 @@
 {
-	"ts-node": {
-		"skipIgnore": true,
-		"transpileOnly": true
-	},
-	"extends": "@wildpeaks/tsconfig-node"
+	"extends": "@wildpeaks/tsconfig"
 }


### PR DESCRIPTION
Removed redundant `prettier` dependency (the VSCode extension can use the global version now).

Upgraded Eslint & TS configs.

Added `@types/node` dev dependency (because the new tsconfig package no longer ships with `@types/node`).