### PR TITLE
Updates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,2 @@
 *.yml
 package.json
-/test/fixtures

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-	"mochaExplorer.require": "ts-node/register/transpile-only",
+	"mochaExplorer.require": "ts-node/register",
 	"mochaExplorer.files": "test/**/*.test.ts",
 	"eslint.validate": [
 		"typescript"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/mocha": "8.2.0",
     "@types/node": "14.14.21",
-    "@wildpeaks/eslint-config-typescript": "11.0.0-rc1",
+    "@wildpeaks/eslint-config-typescript": "11.0.0-rc2",
     "@wildpeaks/tsconfig": "4.0.0-rc2",
     "eslint": "7.18.0",
     "mocha": "8.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "src"
   ],
   "scripts": {
-    "test": "mocha -r ts-node/register/transpile-only test/*.test.ts"
+    "test": "mocha -r ts-node/register test/*.test.ts"
   },
   "peerDependencies": {
     "typescript": "*"

--- a/src/frozen.ts
+++ b/src/frozen.ts
@@ -24,8 +24,7 @@ export function arrayRemove<T>(frozenArray: ReadonlyArray<T>, index: number): Re
  * @param newValue The value to add
  */
 export function arrayUniquePush<T>(frozenArray: ReadonlyArray<T>, newValue: T): ReadonlyArray<T> {
-	// eslint-disable-next-line @typescript-eslint/prefer-includes
-	return frozenArray.indexOf(newValue) === -1 ? arrayPush(frozenArray, newValue) : frozenArray;
+	return frozenArray.includes(newValue) ? frozenArray : arrayPush(frozenArray, newValue);
 }
 
 /**


### PR DESCRIPTION
Upgraded the Eslint config.

Simplified `arrayUniquePush` using [Array.includes](https://caniuse.com/array-includes), meaning you'd need a Polyfill if you still target IE11, so I'll make a major version bump for the next release.