### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "lint": "eslint src/*.ts test/*.ts",
     "test": "mocha -r ts-node/register test/*.test.ts"
   },
-  "peerDependencies": {
-    "typescript": "*"
-  },
   "devDependencies": {
     "@types/mocha": "8.2.2",
     "@types/node": "14.14.37",


### PR DESCRIPTION
It's not needed because the code doesn't directly import the `typescript` package itself.

But now that NPM7 will install peerDependencies, I'd rather tidy up and avoid redundant dependencies (especially as it might install a different version from peerDependencies than the one the user expects).

Ideally, I wish Typescript could use export maps to specify a TS-only entry point to the package (similar to the `types` property) because I'm not fond of passing a .ts file in `main` but it's the only clean way for publish TS packages (because pre-compiling to JS isn't an option given you can't guess what settings the user of the package has in their project, and transpiling down to ES5 would add bloat when one targets only modern browsers).